### PR TITLE
feature: Add initial code of conduct, contribution guide, and PR temp…

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,80 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Contacting individual members, contributors, or leaders privately, outside designated community mechanisms, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at opensource@github.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0, available at <https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at <https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+Thank you for your interest in contributing to Aligent open source projects!
+
+For an overview of features and usage consult the README file at the root of the repository.
+
+# Contribution Guide
+
+## Issues
+
+If you identify and issue, please first search of the issue already exists, and provide further clarifications on that where possible. If the related issue doesn't exist, then please open one and provide as much information as possible.
+
+## Contributing to an Issue
+
+Scan through our existing issues to find one that interests you. You can narrow down the search using labels as filters. See "Label reference" for more information. As a general rule, we assign issues to our internal team only. If you find an issue to work on, you are welcome to open a PR with a fix.
+
+## Contribution workflow
+
+1. [Fork the repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo).
+2. Install or update required dependencies. For more information consult the README at the root of the repository.
+3. Create a working branch and start with your changes!
+
+## Commit Guidelines
+
+When making commits, please adhere to the following guidelines:
+
+- Use the present tense ("Add feature" not "Added feature")
+- Use clear and concise commit messages
+- Reference any relevant issues or pull requests in your commit message using the appropriate keywords (Fixes #issue-number, Resolves #pull-request-number, etc.)
+- Limit the first line to 72 characters or less
+- Make sure each commit represents a logical unit of work
+
+## Pull Requests Guidelines
+
+To ensure a smooth review process and increase the chances of your pull request being merged, please follow these guidelines:
+
+- Ensure that your pull request addresses an existing issue or feature request. If none exists, consider opening one to discuss your proposed changes before submitting the pull request.
+- Provide a clear and descriptive title for your pull request.
+- Include a detailed description of the changes you have made. Explain the purpose and benefits of your changes.
+- Ensure that your code adheres to the project's coding conventions and style guidelines.
+- Include any necessary documentation updates to reflect your changes.
+- Test your changes thoroughly to avoid introducing new bugs.
+- Keep your pull request focused and limited to a single logical change. If you have multiple unrelated changes, consider submitting separate pull requests.
+- Be responsive to any feedback or requests for changes during the review process. Engage in constructive discussions to address any concerns raised by the reviewers.
+- Once your pull request has been approved, it will be merged by the project maintainers.
+
+Thank you for your valuable contributions! 🎉
+
+## Updating documentation
+
+Keeping the documentation up-to-date is essential for maintaining the project's usability and ensuring that users have the necessary information. If you make changes to the codebase, please consider updating the relevant documentation, including the README files.
+
+Make sure the documentation accurately reflects the changes you have made and provides clear instructions or explanations for users. Also, check for any outdated information and remove or update it accordingly.
+
+## Note for Maintainers
+
+The release process outlined above is primarily applicable to maintainers of open source repositories. As a maintainer, it is your responsibility to review and merge pull requests, create releases, and manage versioning.
+
+Additionally, as a maintainer, please ensure that the README files for each package/tool are kept up-to-date. When introducing changes or new features, update the corresponding README to reflect those changes accurately. This will help users understand the functionality and usage of each package or tool.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# code-of-conduct
+# Aligent Code of Conduct
+
+This repository contains the standard [Code of Conduct](./CODE_OF_CONDUCT.md), [contribution guide](./CONTRIBUTING.md), and [pull request template](./pull_request_template.md) for Aligent open source projects.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,13 @@
+**Description of the proposed changes**
+
+**Screenshots (if applicable)**
+
+**Other solutions considered (if any)**
+
+**Notes to PR author**
+
+⚠️ Please make sure the changes adhere to the guidelines mentioned in our [contribution guide](https://github.com/aligent/code-of-conduct/blob/main/CONTRIBUTING.md).
+
+Notes to reviewers
+
+🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback


### PR DESCRIPTION
Adding documents adapted from what we were going to add to the [graphql-mesh](https://github.com/aligent/aligent-graphql-mesh/pull/30/files#diff-d915bbd02901ffd904dbc4f89f0849e9485d246c2b5b0fbdc021f564550837bb) repo.

I have slightly altered the language to be more agnostic of the project and tech stack.